### PR TITLE
Fixed for Soundcloud

### DIFF
--- a/info.go
+++ b/info.go
@@ -45,7 +45,7 @@ type Info struct {
 	} `json:"subtitles"`
 	AutomaticCaptions struct {
 	} `json:"automatic_captions"`
-	Duration      int         `json:"duration"`
+	Duration      float64     `json:"duration"`
 	AgeLimit      int         `json:"age_limit"`
 	Annotations   interface{} `json:"annotations"`
 	Chapters      interface{} `json:"chapters"`


### PR DESCRIPTION
When using Soundcloud URLs, I get the error:
```
Error in cmd: json: cannot unmarshal number 248.108 into Go struct field Info.duration of type int
```
Changing the Info struct fixes this.