### PR TITLE
Wait for the process to finish, even on a decoding error

### DIFF
--- a/goydl.go
+++ b/goydl.go
@@ -106,6 +106,9 @@ func (ydl *youtubeDl) GetInfo() (Info, error) {
 	}
 
 	if err := json.NewDecoder(stdOut).Decode(&ydl.Info); err != nil {
+		// We need to wait for the command to exit, so we don't end up creating
+		// defunct processes.
+		_ = cmd.Wait()
 		return Info{}, err
 	}
 


### PR DESCRIPTION
This prevents creating lingering defunct processes.